### PR TITLE
ci: move workflows from hemilabs/actions

### DIFF
--- a/.github/workflows/js-checks.yml
+++ b/.github/workflows/js-checks.yml
@@ -1,0 +1,47 @@
+# Copyright (c) 2024-2026 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+
+name: JS Checks
+
+on:
+  workflow_call:
+    inputs:
+      fetch-depth:
+        description: Number of commits to fetch. 0 indicates all history for all branches and tags.
+        default: 1
+        type: number
+      node-versions:
+        description: Array of Node versions to test with (JSON string)
+        default: "['']"
+        type: string
+
+jobs:
+  run-checks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+      - uses: hemilabs/actions/setup-node-env@v2
+      - run: npm run --if-present format:check
+      - run: npm run --if-present lint
+      - run: npm run --if-present --include-workspace-root --workspaces deps:check
+      - run: npm run --if-present --include-workspace-root --workspaces build
+  run-tests:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+      - uses: hemilabs/actions/setup-node-env@c86350368ebf1124e81813d1497fb44606f3b6c1 # v2.0.0
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm run --if-present --include-workspace-root --workspaces test
+    strategy:
+      matrix:
+        node-version: ${{ fromJSON(inputs.node-versions) }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,29 @@
+# Copyright (c) 2024-2026 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+
+name: NPM Publish
+
+on:
+  workflow_call:
+    inputs:
+      fetch-depth:
+        description: Number of commits to fetch. 0 indicates all history for all branches and tags.
+        default: 1
+        type: number
+
+jobs:
+  publish-to-npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: ${{ inputs.fetch-depth }}
+      - uses: hemilabs/actions/setup-node-env@c86350368ebf1124e81813d1497fb44606f3b6c1 # v2.0.0
+      - run: npm run --if-present prepublishOnly
+      # Provenance is enabled by default in trusted publishing
+      # See https://docs.npmjs.com/trusted-publishers#supported-cicd-providers
+      - run: npm publish

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Hemi Labs, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Move `js-checks.yml` and `npm-publish.yml` workflows from `hemilabs/actions` to this repository.

Related to: https://github.com/hemilabs/actions/issues/27
