### PR TITLE
all: add renovate configs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,22 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'local>hemilabs/.github:renovate-config.json5',
+    ':assignAndReview(joshuasing)',
+  ],
+  commitMessagePrefix: 'ci:',
+  commitMessageAction: 'update',
+  commitMessageTopic: '{{depName}}',
+  packageRules: [
+    {
+      description: 'Enable auto-merge on pull requests',
+      matchPackageNames: ['*'],
+      automerge: true,
+      automergeType: 'pr',
+    },
+    {
+      matchUpdateTypes: ['pin', 'pinDigest'],
+      commitMessageAction: 'pin',
+    },
+  ],
+}

--- a/renovate-config.json5
+++ b/renovate-config.json5
@@ -1,0 +1,33 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  description: "Standard preset across hemilabs repositories",
+  extends: [
+    'config:best-practices',
+    ':configMigration',
+    ':pinVersions',
+    ':prConcurrentLimit10',
+    ':rebaseStalePrs',
+    'schedule:weekly',
+    'docker:enableMajor',
+    'docker:pinDigests',
+    'preview:dockerCompose',
+    'preview:dockerVersions',
+    'customManagers:dockerfileVersions',
+    'customManagers:githubActionsVersions',
+    'helpers:pinGitHubActionDigests',
+  ],
+  labels: [
+    'type: dependencies',
+  ],
+  minimumReleaseAge: '3 days',
+  osvVulnerabilityAlerts: true,
+  vulnerabilityAlerts: {
+    enabled: true,
+    addLabels: [
+      'type: security',
+    ],
+    additionalReviewers: [
+      'team:security',
+    ],
+  },
+}


### PR DESCRIPTION
Add a reusable `renovate-config.json5` config file for Renovate, and a `.github/renovate.json5` config for Renovate in this repository.