### PR TITLE
feat: Add --access public flag for first publications

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,4 +26,4 @@ jobs:
       - run: npm run --if-present prepublishOnly
       # Provenance is enabled by default in trusted publishing
       # See https://docs.npmjs.com/trusted-publishers#supported-cicd-providers
-      - run: npm publish
+      - run: npm publish --access public


### PR DESCRIPTION
This PR adds the `--access public` so the command does not fail the first time a lib is published. See [npm docs](https://docs.npmjs.com/generating-provenance-statements)

> If you are publishing a package for the first time you will also need to explicitly set access to public:

```
npm publish --provenance --access public
```

However, `--provenance` is enabled by default so we can skip it.  
As we're not publishing private packages, this is not a problem.  
Subsequent publishes are not affected by `--access public`, so adding this is safe (See [access flag docs](https://docs.npmjs.com/cli/v8/commands/npm-publish#access))