### PR TITLE
ci: move docker workflow from hemilabs/actions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,100 @@
+# Copyright (c) 2024-2026 Hemi Labs, Inc.
+# Use of this source code is governed by the MIT License,
+# which can be found in the LICENSE file.
+
+name: "Docker"
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Application version (e.g. v1.0.0)"
+        type: string
+        required: true
+      context:
+        description: "Docker build context"
+        type: string
+        default: "${{ github.workspace }}"
+      platforms:
+        description: "Platforms to build image for (newline/comma separated)"
+        type: string
+        default: "linux/amd64"
+      file:
+        description: "Dockerfile to build"
+        type: string
+        default: "${{ github.workspace }}/Dockerfile"
+      tags:
+        description: "Docker image tags (newline/comma separated)"
+        type: string
+        required: true
+      build-args:
+        description: "Additional Docker build args (built-in: VERSION, VCS_REF, BUILD_DATE)"
+        type: string
+        default: ""
+      prebuild:
+        description: "Commands to execute before building Docker image"
+        type: string
+      dockerhub:
+        description: "Push to Docker Hub (requires secrets to be set)"
+        type: boolean
+        default: false
+    secrets:
+      DOCKERHUB_USERNAME:
+        description: "Docker Hub username"
+        required: false
+      DOCKERHUB_PASSWORD:
+        description: "Docker Hub authentication token"
+        required: false
+
+jobs:
+  docker:
+    name: "Build and push"
+    runs-on: "ubuntu-latest"
+    permissions:
+      contents: read
+      packages: write # Needed to push to GitHub Container Registry
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: "Setup QEMU"
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+
+      - name: "Setup Docker Buildx"
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: "Login to DockerHub"
+        if: inputs.dockerhub
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: "${{ secrets.DOCKERHUB_USERNAME }}"
+          password: "${{ secrets.DOCKERHUB_PASSWORD }}"
+
+      - name: "Login to GitHub Container Registry"
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.repository_owner }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Prepare to build"
+        id: "prepare"
+        run: |
+          echo "build_date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: "Pre-build"
+        if: inputs.prebuild != ''
+        run: "${{ inputs.prebuild }}"
+
+      - name: "Build and push"
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: "${{ inputs.context }}"
+          platforms: "${{ inputs.platforms }}"
+          file: "${{ inputs.file }}"
+          push: true
+          build-args: |
+            VERSION=${{ inputs.version }}
+            VCS_REF=${{ github.sha }}
+            BUILD_DATE=${{ steps.prepare.outputs.build_date }}
+            ${{ inputs.build-args }}
+          tags: "${{ inputs.tags }}"


### PR DESCRIPTION
Add the `docker.yml` workflow file from https://github.com/hemilabs/actions - used in a couple of repositories.