### PR TITLE
ci: update hemilabs/actions/setup-node-env to 42a939f

### DIFF
--- a/.github/workflows/js-checks-pnpm.yml
+++ b/.github/workflows/js-checks-pnpm.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
-      - uses: hemilabs/actions/setup-node-env@dbe5c7bf1c9de8910bd0268ac55a4e8043ef8a2d
+      - uses: hemilabs/actions/setup-node-env@42a939f90638fa4c3f3820dbb9a3cdd8404a2590
         with:
           package-manager: pnpm
       - run: pnpm run --if-present format:check
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
-      - uses: hemilabs/actions/setup-node-env@dbe5c7bf1c9de8910bd0268ac55a4e8043ef8a2d
+      - uses: hemilabs/actions/setup-node-env@42a939f90638fa4c3f3820dbb9a3cdd8404a2590
         with:
           node-version: ${{ matrix.node-version }}
           package-manager: pnpm

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: ${{ inputs.fetch-depth }}
-      - uses: hemilabs/actions/setup-node-env@dbe5c7bf1c9de8910bd0268ac55a4e8043ef8a2d # v2.0.0
+      - uses: hemilabs/actions/setup-node-env@42a939f90638fa4c3f3820dbb9a3cdd8404a2590 # v2.0.0
         with:
           package-manager: ${{ inputs.package-manager }}
       # The below commands can be run with either npm or pnpm, as both support the same CLI


### PR DESCRIPTION
## Summary

Updates the `setup-node-env` action reference from `dbe5c7b` to `42a939f` in the following workflows:
- `js-checks-pnpm.yml`
- `npm-publish.yml`

This ensures the workflows use the latest version of the action.

## Changes

- Updated action hash in js-checks-pnpm workflow (2 occurrences)
- Updated action hash in npm-publish workflow (1 occurrence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)