### PR TITLE
ci: publish via pnpm when selected

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,8 +29,13 @@ jobs:
       - uses: hemilabs/actions/setup-node-env@8f87619b7f0122c39e14a32514ab3e4e0d4c3966 # v2.3.0
         with:
           package-manager: ${{ inputs.package-manager }}
-      # The below commands can be run with either npm or pnpm, as both support the same CLI
-      - run: npm run --if-present prepublishOnly
       # Provenance is enabled by default in trusted publishing
       # See https://docs.npmjs.com/trusted-publishers#supported-cicd-providers
-      - run: npm publish --access public
+      - if: inputs.package-manager == 'npm'
+        run: |
+          npm run --if-present prepublishOnly
+          npm publish --access public
+      - if: inputs.package-manager == 'pnpm'
+        run: |
+          pnpm run --if-present prepublishOnly
+          pnpm publish --access public


### PR DESCRIPTION
## Summary

Branch the `npm-publish` reusable workflow's `prepublishOnly` and `publish` steps on `inputs.package-manager`, so callers that opt into pnpm actually invoke `pnpm publish` instead of `npm publish`.

This is needed to unlock pnpm-specific publish behavior. Concretely, for a `publishConfig` like:

```json
"publishConfig": {
  "access": "public",
  "exports": {
    ".": {
      "default": "./_esm/index.js",
      "types": "./_types/index.d.ts"
    },
    "./actions": {
      "default": "./_esm/actions/index.js",
      "types": "./_types/actions/index.d.ts"
    },
    "./package.json": "./package.json"
  },
  "main": "./_esm/index.js",
  "provenance": true,
  "types": "./_types/index.d.ts"
}
```

`npm publish` only honors the npm config keys (`access`, `provenance`) and ignores the `package.json` field overrides (`main`, `types`, `exports`) — it ships the raw top-level fields, which would point at source paths and break consumers. `pnpm publish` reads those overrides and rewrites the published `package.json` accordingly. I need this for publishing the vetro packages.

Dispatch is implemented via step-level `if:` guards (one for `npm`, one for `pnpm`) rather than interpolating `${{ inputs.package-manager }}` into `run:`, to avoid a GitHub Actions script-injection vector if a caller ever passed an unexpected value.

Related to vetro-protocol/vetro-monorepo#423.